### PR TITLE
Property names should be spelled correctly

### DIFF
--- a/serverless/src/controllers/HealthController.ts
+++ b/serverless/src/controllers/HealthController.ts
@@ -15,7 +15,7 @@ export class HealthController extends Controller {
   public async get(): Promise<HealthResponse> {
     return {
       name: packageJson.name,
-      healty: true,
+      healthy: true,
       now: new Date(),
       version: packageJson.version,
     };


### PR DESCRIPTION
Trivial spelling correction in property names of returned object